### PR TITLE
Losen enum parent class requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PHP-Enum changelog
 
+## Unreleased
+
+* **[CHANGED]** Enum class no longer must be immediate parent
+
 ## 1.1.1 (2018-04-29)
 
 * **[CHANGED]** Optimized functions imports

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This class also exposes few public static and non static methods which are liste
 - `final ordinal(): int` - returns ordinal number of that enum object (it's position in the collection) starting from 0
 - `final isAnyOf(Enum ...$enums): bool` - returns `true` if enum object is in the `$enums` list, `false` otherwise
 
-Other methods serve as a way to restrict inconsistent behaviour, for example, to have to distinct objects of the same enum name. Check the [Restrictions](#restrictions) section for more info. 
+Other methods serve as a way to restrict inconsistent behaviour, for example, to have two distinct objects of the same enum name. Check the [Restrictions](#restrictions) section for more info.
 
 ## Usage
 
@@ -111,6 +111,12 @@ Every call to the same enum will return that same object so you can safely use i
 
 Since enums are created using static method, it's recommended to type-hint your class with existing static methods using `@method static YourEnumClass YOUR_ENUM_NAME`.
 
+### More than one parent
+
+It is possible to have more than one class between defining enum class and `\Zlikavac32\Enum\Enum` class with a few restrictions (check [Restrictions regarding inheritance](#restrictions-regarding-inheritance)).
+
+To see an example, open [examples/hashable_enum.php](examples/hashable_enum.php).
+
 ## Restrictions
 
 To mitigate wrong usage and sleepless nights in debugging, some restrictions are placed. They exist not because I want them to, but to serve as an early warning that something could go wrong in the long run. If you try really hard, you can still avoid them but then what's the purpose of this library to you?
@@ -122,6 +128,12 @@ In order to try to avoid misuse as much as possible, you can not serialize/unser
 ### No cloning
 
 The reasoning behind this is the same as with serialisation.
+
+### Restrictions regarding inheritance
+
+- no class in between can define `enumerate` method
+- every class in the chain must be defined as abstract
+- defining enum class must be first parent for the concrete enum object
 
 ### Reserved methods
 

--- a/examples/hashable_enum.php
+++ b/examples/hashable_enum.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zlikavac32\Rick\Examples;
+
+use Ds\Hashable;
+use Ds\Set;
+use Zlikavac32\Enum\Enum;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (!extension_loaded('ds')) {
+    fwrite(STDERR, "You need the ds library to run this example");
+
+    exit(1);
+}
+
+/**
+ * Example that show how to extend Enum with custom behaviour
+ */
+abstract class HashableEnum extends Enum implements Hashable
+{
+
+    public function equals($object): bool
+    {
+        return $object === $this;
+    }
+
+    public function hash(): string
+    {
+        // this works under assumption that you use this library correctly (same object has same hash)
+        return spl_object_hash($this);
+    }
+}
+
+/**
+ * @method static YesNo YES
+ * @method static YesNo NO
+ */
+abstract class YesNo extends HashableEnum
+{
+
+    protected static function enumerate(): array
+    {
+        return [
+            'YES',
+            'NO',
+        ];
+    }
+}
+
+var_dump(YesNo::YES() instanceof Hashable); // bool(true)
+
+$set = new Set();
+
+$set->add(YesNo::NO());
+
+var_dump($set->contains(YesNo::NO())); // bool(true)
+var_dump($set->contains(YesNo::YES())); // bool(false)
+
+$set->add(YesNo::YES());
+
+var_dump($set->contains(YesNo::NO())); // bool(true)
+var_dump($set->contains(YesNo::YES())); // bool(true)
+
+$set->remove(YesNo::NO());
+
+var_dump($set->contains(YesNo::NO())); // bool(false)
+var_dump($set->contains(YesNo::YES())); // bool(true)

--- a/examples/hashable_enum.php
+++ b/examples/hashable_enum.php
@@ -10,8 +10,12 @@ use Zlikavac32\Enum\Enum;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-if (!extension_loaded('ds')) {
-    fwrite(STDERR, "You need the ds library to run this example");
+if (
+    !interface_exists(Hashable::class)
+    ||
+    !class_exists(Set::class)
+) {
+    fwrite(STDERR, "You need the ds library to run this example (composer or native version both should work well)");
 
     exit(1);
 }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -57,7 +57,6 @@ abstract class Enum implements Serializable, JsonSerializable
 
     private function assertValidConstructionContext(): void
     {
-        //Expected usage is new class extends Enum so first parent should be our construction context
         if (isset(self::$enumConstructionContext[get_parent_class($this)])) {
             return ;
         }
@@ -282,7 +281,7 @@ abstract class Enum implements Serializable, JsonSerializable
 
     private static function discoverEnumerationObjectsForClass(string $class)
     {
-        assertEnumClassIsAbstract($class);
+        assertEnumClassAdheresConstraints($class);
 
         /* @var Enum[]|string[] $objectsOrEnumNames */
         $objectsOrEnumNames = static::enumerate();

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -6,8 +6,12 @@ namespace Zlikavac32\Enum\Tests;
 
 use LogicException;
 use PHPUnit\Framework\TestCase;
+use Zlikavac32\Enum\Tests\Fixtures\AbstractEnumWithoutEnumerate;
 use Zlikavac32\Enum\Tests\Fixtures\DuplicateNameEnum;
 use Zlikavac32\Enum\Tests\Fixtures\EnumThatDependsOnEnum;
+use Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsNonAbstractEnumWithoutEnumerate;
+use Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsValidEnum;
+use Zlikavac32\Enum\Tests\Fixtures\ValidEnumWithOneParent;
 use Zlikavac32\Enum\Tests\Fixtures\EnumWithSomeVeryVeryLongNameA;
 use Zlikavac32\Enum\Tests\Fixtures\EnumWithSomeVeryVeryLongNameB;
 use Zlikavac32\Enum\Tests\Fixtures\InvalidAliasNameEnum;
@@ -409,5 +413,34 @@ class EnumTest extends TestCase
         } catch (LogicException $e) {
             $this->fail('Workaround no longer works');
         }
+    }
+
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage Enum Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsValidEnum extends
+     *                           Zlikavac32\Enum\Tests\Fixtures\ValidStringEnum which already defines enumerate()
+     *                           method
+     */
+    public function testThatNonDefiningEnumClassInChainMustNotDefineEnumerate(): void
+    {
+        EnumThatExtendsValidEnum::ENUM_A();
+    }
+
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage Class Zlikavac32\Enum\Tests\Fixtures\NonAbstractEnumWithoutEnumerate must be also
+     *                           abstract (since
+     *                           Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsNonAbstractEnumWithoutEnumerate extends
+     *                           it)
+     */
+    public function testThatNonDefiningEnumClassInChainMustBeAbstract(): void
+    {
+        EnumThatExtendsNonAbstractEnumWithoutEnumerate::ENUM_A();
+    }
+
+    public function testThatEnumWithAbstractParentCanBeConstructed(): void
+    {
+        $this->assertTrue(ValidEnumWithOneParent::ENUM_A() instanceof AbstractEnumWithoutEnumerate);
+        $this->assertTrue(ValidEnumWithOneParent::ENUM_A() instanceof ValidEnumWithOneParent);
     }
 }

--- a/tests/Fixtures/AbstractEnumWithoutEnumerate.php
+++ b/tests/Fixtures/AbstractEnumWithoutEnumerate.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zlikavac32\Enum\Tests\Fixtures;
+
+use Zlikavac32\Enum\Enum;
+
+abstract class AbstractEnumWithoutEnumerate extends Enum
+{
+
+}

--- a/tests/Fixtures/EnumThatExtendsNonAbstractEnumWithoutEnumerate.php
+++ b/tests/Fixtures/EnumThatExtendsNonAbstractEnumWithoutEnumerate.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zlikavac32\Enum\Tests\Fixtures;
+
+/**
+ * @method static EnumThatExtendsNonAbstractEnumWithoutEnumerate ENUM_A
+ */
+abstract class EnumThatExtendsNonAbstractEnumWithoutEnumerate extends NonAbstractEnumWithoutEnumerate
+{
+
+    protected static function enumerate(): array
+    {
+        return [
+            'ENUM_A',
+        ];
+    }
+}

--- a/tests/Fixtures/EnumThatExtendsValidEnum.php
+++ b/tests/Fixtures/EnumThatExtendsValidEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zlikavac32\Enum\Tests\Fixtures;
+
+/**
+ * @method static EnumThatExtendsValidEnum ENUM_A
+ */
+abstract class EnumThatExtendsValidEnum extends ValidStringEnum
+{
+    protected static function enumerate(): array
+    {
+        return [
+            'ENUM_A'
+        ];
+    }
+}

--- a/tests/Fixtures/NonAbstractEnumWithoutEnumerate.php
+++ b/tests/Fixtures/NonAbstractEnumWithoutEnumerate.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zlikavac32\Enum\Tests\Fixtures;
+
+use Zlikavac32\Enum\Enum;
+
+class NonAbstractEnumWithoutEnumerate extends Enum
+{
+
+}

--- a/tests/Fixtures/ValidEnumWithOneParent.php
+++ b/tests/Fixtures/ValidEnumWithOneParent.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zlikavac32\Enum\Tests\Fixtures;
+
+/**
+ * @method static ValidStringEnum ENUM_A
+ */
+abstract class ValidEnumWithOneParent extends AbstractEnumWithoutEnumerate
+{
+
+    protected static function enumerate(): array
+    {
+        return [
+            'ENUM_A',
+        ];
+    }
+}

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -8,7 +8,11 @@ use LogicException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Throwable;
+use function Zlikavac32\Enum\assertNoParentHasEnumerateMethodForClass;
+use Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsNonAbstractEnumWithoutEnumerate;
+use Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsValidEnum;
 use Zlikavac32\Enum\Tests\Fixtures\NonAbstractEnum;
+use Zlikavac32\Enum\Tests\Fixtures\ValidEnumWithOneParent;
 use Zlikavac32\Enum\Tests\Fixtures\ValidStringEnum;
 use function sprintf;
 use function Zlikavac32\Enum\assertElementNameIsString;
@@ -144,5 +148,39 @@ class functionsTest extends TestCase
     private function failWithThrowable(Throwable $e): void
     {
         $this->fail(sprintf('No exception was expected but got: %s', $e->getMessage()));
+    }
+
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage Enum Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsValidEnum extends
+     *                           Zlikavac32\Enum\Tests\Fixtures\ValidStringEnum which already defines enumerate()
+     *                           method
+     */
+    public function testThatExceptionIsThrownWhenParentHasEnumerate(): void
+    {
+        assertNoParentHasEnumerateMethodForClass(EnumThatExtendsValidEnum::class);
+    }
+
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage Class Zlikavac32\Enum\Tests\Fixtures\NonAbstractEnumWithoutEnumerate must be also
+     *                           abstract (since
+     *                           Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsNonAbstractEnumWithoutEnumerate extends
+     *                           it)
+     */
+    public function testThatExceptionIsThrownWhenParentIsNotAbstract(): void
+    {
+        assertNoParentHasEnumerateMethodForClass(EnumThatExtendsNonAbstractEnumWithoutEnumerate::class);
+    }
+
+    public function testThatGoodEnumWithParentPasses(): void
+    {
+        try {
+            assertNoParentHasEnumerateMethodForClass(ValidEnumWithOneParent::class);
+
+            $this->assertTrue(true);
+        } catch (Throwable $e) {
+            $this->failWithThrowable($e);
+        }
     }
 }


### PR DESCRIPTION
Multiple classes can now be added in the inheritance chain as long no other class between defining enum class and `Zlikavac32\Enum\Enum`  has `enumerate` method and every class is defined as abstract.

This fixes #2 