### PR TITLE
Fix method regex capturing to much

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -293,7 +293,7 @@ abstract class Enum implements Serializable, JsonSerializable
             );
         }
 
-        $regex = '/@method\s+static\s+[^\s]+\s+(.+)\s*(?:\(\))?/';
+        $regex = '/@method\s+static\s+[^\s]+\s+(\w+)\s*(?:\(\))?\s*$/m';
 
         if (!preg_match_all($regex, $docBlock, $matches, PREG_SET_ORDER)) {
             throw new LogicException(sprintf('Enum %s must define at least one element', $class));

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -212,7 +212,7 @@ class EnumTest extends TestCase
     public function testThatInvalidAliasNameThrowsException(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Element name "INVA LID" does not match pattern /^[a-zA-Z_][a-zA-Z_0-9]*$/');
+        $this->expectExceptionMessage('Element name "3ID" does not match pattern /^[a-zA-Z_][a-zA-Z_0-9]*$/');
 
         InvalidAliasNameEnum::values();
     }
@@ -410,5 +410,31 @@ class EnumTest extends TestCase
         $this->expectExceptionMessage('Enum Zlikavac32\Enum\Tests\Fixtures\EnumThatEnumeratesToLittle does not enumerate [ENUM_B, ENUM_C] which are found in PHPDoc');
 
         EnumThatEnumeratesToLittle::ENUM_A();
+    }
+
+    public function testThatCarriageReturnInMethodNameIsNotCaptured(): void
+    {
+        // to avoid editor accidentally deleting \r, this enum fixture is evaluated
+        $code = <<<'PHP'
+namespace Zlikavac32\Enum\Tests\Fixtures;
+
+use Zlikavac32\Enum\Enum;
+
+/**
+ * @method static EnumWithCarriageReturnInMethod ENUM_A%s
+ */
+abstract class EnumWithCarriageReturnInMethod extends Enum
+{
+
+}
+PHP;
+
+        eval(sprintf($code, "\r"));
+
+        $this->assertSame(
+            0,
+            \Zlikavac32\Enum\Tests\Fixtures\EnumWithCarriageReturnInMethod::ENUM_A()
+                            ->ordinal()
+        );
     }
 }

--- a/tests/Fixtures/InvalidAliasNameEnum.php
+++ b/tests/Fixtures/InvalidAliasNameEnum.php
@@ -7,14 +7,9 @@ namespace Zlikavac32\Enum\Tests\Fixtures;
 use Zlikavac32\Enum\Enum;
 
 /**
- * @method static InvalidAliasNameEnum INVA LID
+ * @method static InvalidAliasNameEnum 3ID
  */
 abstract class InvalidAliasNameEnum extends Enum
 {
-    protected static function enumerate(): array
-    {
-        return [
-            'INVA LID',
-        ];
-    }
+
 }


### PR DESCRIPTION
Regex had no $ anchor so it capture to much. Whole regex is now
a bit modified to be more specific when capturing.

This fixes https://github.com/zlikavac32/php-enum/issues/4