### PR TITLE
Add support for PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ install: composer update $COMPOSER_FLAGS
 matrix:
     include:
         -
-            php: 7.4
+            php: 8.0
         -
-            php: 7.4
+            php: 8.0
             env: COMPOSER_FLAGS='--prefer-lowest'
         -
             php: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PHP-Enum changelog
 
+## Unreleased
+
+* **[CHANGED]** Added support for PHP 8.0
+
 ## 3.0.0 (2020-04-08)
 
 * **[CHANGED]** `\Zlikavac32\Enum\assertNoParentHasEnumerateMethodForClass()` is renamed to `\Zlikavac32\Enum\assertEnumClassParentsAdhereConstraints()`

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^7.4",
+        "php": "^8.0",
         "ext-json": "*"
     },
     "require-dev": {

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -101,7 +101,7 @@ abstract class Enum implements Serializable, JsonSerializable
     /**
      * @throws Throwable
      */
-    final public static function __set_state()
+    final public static function __set_state(array $array): object
     {
         throw self::createNoSerializeUnserializeException();
     }
@@ -109,7 +109,7 @@ abstract class Enum implements Serializable, JsonSerializable
     /**
      * @throws Throwable
      */
-    final public function __wakeup()
+    final public function __wakeup(): void
     {
         throw self::createNoSerializeUnserializeException();
     }
@@ -117,7 +117,7 @@ abstract class Enum implements Serializable, JsonSerializable
     /**
      * @throws Throwable
      */
-    final public function __sleep()
+    final public function __sleep(): array
     {
         throw self::createNoSerializeUnserializeException();
     }
@@ -125,7 +125,7 @@ abstract class Enum implements Serializable, JsonSerializable
     /**
      * @throws Throwable
      */
-    final public function serialize()
+    final public function serialize(): array
     {
         throw self::createNoSerializeUnserializeException();
     }
@@ -150,7 +150,7 @@ abstract class Enum implements Serializable, JsonSerializable
         return $this->name();
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->name();
     }

--- a/src/EnumNotFoundException.php
+++ b/src/EnumNotFoundException.php
@@ -11,14 +11,9 @@ use function sprintf;
 class EnumNotFoundException extends LogicException
 {
 
-    private string $missingEnumName;
-    private string $enumClass;
-
-    public function __construct(string $missingEnumName, string $enumClass, int $code = 0, Throwable $previous = null)
+    public function __construct(private string $missingEnumName, private string $enumClass, int $code = 0, Throwable $previous = null)
     {
         parent::__construct(sprintf('Enum element %s missing in %s', $missingEnumName, $enumClass), $code, $previous);
-        $this->missingEnumName = $missingEnumName;
-        $this->enumClass = $enumClass;
     }
 
     public function missingEnumName(): string

--- a/src/UnhandledEnumException.php
+++ b/src/UnhandledEnumException.php
@@ -9,16 +9,14 @@ use LogicException;
 class UnhandledEnumException extends LogicException
 {
 
-    private Enum $enum;
     private string $enumFqn;
 
-    public function __construct(Enum $enum)
+    public function __construct(public Enum $enum)
     {
         $fqn = get_parent_class($enum);
 
         parent::__construct(sprintf('Enum %s::%s() is left unhandled', $fqn, $enum->name()));
 
-        $this->enum = $enum;
         $this->enumFqn = $fqn;
     }
 

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -263,7 +263,7 @@ class EnumTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Serialization/deserialization of enum element is not allowed');
 
-        ValidStringEnum::__set_state();
+        ValidStringEnum::__set_state([]);
     }
 
     public function testThatSleepThrowsException(): void


### PR DESCRIPTION
Methods that needed prototype change have been
changed.

Property promotion is also used where possible.