### PR TITLE
Rename namespace and class to ZEnum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PHP-Enum changelog
 
+## Unreleased
+
+* **[CHANGED]** Renamed namespace and class from `Enum` to `ZEnum` to allow PHP 8.1
+
 ## 4.0.0 (2021-04-12)
 
 * **[CHANGED]** Added support for PHP 8.0

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Every call to enum object guarantees to return same instance every time it is ca
 
 ## API
 
-Main class is `\Zlikavac32\Enum\Enum` which serves as base enum (I'd rather have `enum` keywords, but life isn't perfect). You have to extend it and provide list of static methods in the class PHPDoc comment. Check the [Usage](#usage) section to see a real example.
+Main class is `\Zlikavac32\ZEnum\ZEnum` which serves as base enum (I'd rather have `enum` keywords, but life isn't perfect). You have to extend it and provide list of static methods in the class PHPDoc comment. Check the [Usage](#usage) section to see a real example.
 
 This class also exposes few public static and non static methods which are listed bellow.
 
@@ -99,7 +99,7 @@ In `src/functions.php` are some helper function that could help you asserting ce
 
 ## Usage
 
-Create an abstract class that will represent your enum and let it extend `\Zlikavac32\Enum\Enum`. 
+Create an abstract class that will represent your enum and let it extend `\Zlikavac32\ZEnum\ZEnum`.
 
 You must list static methods in the class PHPDoc comment. Method names are used as enum names.
 
@@ -108,7 +108,7 @@ You must list static methods in the class PHPDoc comment. Method names are used 
  * @method static YesNo YES
  * @method static YesNo NO
  */
-abstract class YesNo extends \Zlikavac32\Enum\Enum
+abstract class YesNo extends \Zlikavac32\ZEnum\ZEnum
 {
 
 }
@@ -127,7 +127,7 @@ It's also possible to manually instantiate enum objects and return them as a map
  * @method static YesNo YES
  * @method static YesNo NO
  */
-abstract class YesNo extends \Zlikavac32\Enum\Enum
+abstract class YesNo extends \Zlikavac32\ZEnum\ZEnum
 {
     protected static function enumerate(): array
     {
@@ -145,7 +145,7 @@ Note that every enum name listed in the PHPDoc comment must exist as a key in th
 
 It would be nice if we'd get notified when we have an unhandled branch when new enum names are added. This is not available without a bit of manual work.
 
-A convenient `\Zlikavac32\Enum\UnhandledEnumException` is provided to make that manual work a bit easier. Easier in a sense that we get nice error message.
+A convenient `\Zlikavac32\ZEnum\UnhandledEnumException` is provided to make that manual work a bit easier. Easier in a sense that we get nice error message.
 
 It's intended to be thrown in the default case when checking every enum name.
 
@@ -162,7 +162,7 @@ switch ($enum) {
 
 ### More than one parent
 
-It is possible to have more than one class between defining enum class and `\Zlikavac32\Enum\Enum` class with a few restrictions (check [Restrictions regarding inheritance](#restrictions-regarding-inheritance)).
+It is possible to have more than one class between defining enum class and `\Zlikavac32\ZEnum\ZEnum` class with a few restrictions (check [Restrictions regarding inheritance](#restrictions-regarding-inheritance)).
 
 To see an example, open [examples/hashable_enum.php](examples/hashable_enum.php).
 
@@ -187,7 +187,7 @@ The reasoning behind this is the same as with serialisation.
 
 ### Reserved methods
 
-None of the public methods in `\Zlikavac32\Enum\Enum` can be used as an enum name. Check the [API](#api) section for more details.
+None of the public methods in `\Zlikavac32\ZEnum\ZEnum` can be used as an enum name. Check the [API](#api) section for more details.
 
 ## Limitations
 

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
-        "phpspec/phpspec": "^6.1"
+        "phpunit/phpunit": "^9.5",
+        "phpspec/phpspec": "^7.2"
     },
     "autoload": {
         "psr-4": {
-            "Zlikavac32\\Enum\\": "src/"
+            "Zlikavac32\\ZEnum\\": "src/"
         },
         "files": [
             "src/functions.php"
@@ -29,7 +29,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Zlikavac32\\Enum\\Tests\\": "tests/"
+            "Zlikavac32\\ZEnum\\Tests\\": "tests/"
         }
     }
 }

--- a/examples/gender.php
+++ b/examples/gender.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Examples;
+namespace Zlikavac32\ZEnum\Examples;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
@@ -17,7 +17,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
  * @method static Gender MALE
  * @method static Gender FEMALE
  */
-abstract class Gender extends Enum
+abstract class Gender extends ZEnum
 {
     /**
      * @var string

--- a/examples/hashable_enum.php
+++ b/examples/hashable_enum.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Examples;
+namespace Zlikavac32\ZEnum\Examples;
 
 use Ds\Hashable;
 use Ds\Set;
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
@@ -23,7 +23,7 @@ if (
 /**
  * Example that show how to extend Enum with custom behaviour
  */
-abstract class HashableEnum extends Enum implements Hashable
+abstract class HashableEnum extends ZEnum implements Hashable
 {
 
     public function equals($object): bool

--- a/examples/mathematical_operator.php
+++ b/examples/mathematical_operator.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Examples;
+namespace Zlikavac32\ZEnum\Examples;
 
 use LogicException;
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
@@ -25,7 +25,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
  * @method static MathematicalOperator TIMES
  * @method static MathematicalOperator DIV
  */
-abstract class MathematicalOperator extends Enum
+abstract class MathematicalOperator extends ZEnum
 {
     protected static function enumerate(): array
     {

--- a/examples/token.php
+++ b/examples/token.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Examples;
+namespace Zlikavac32\ZEnum\Examples;
 
 use Generator;
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
@@ -24,7 +24,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
  * @method static Token T_NUMBER
  * @method static Token T_INVALID
  */
-abstract class Token extends Enum
+abstract class Token extends ZEnum
 {
     /**
      * @var string

--- a/examples/world_side.php
+++ b/examples/world_side.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Examples;
+namespace Zlikavac32\ZEnum\Examples;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
@@ -18,7 +18,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
  * @method static WorldSide EAST
  * @method static WorldSide WEST
  */
-abstract class WorldSide extends Enum
+abstract class WorldSide extends ZEnum
 {
 
     protected static function enumerate(): array

--- a/examples/yes_no.php
+++ b/examples/yes_no.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Examples;
+namespace Zlikavac32\ZEnum\Examples;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
@@ -16,7 +16,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
  * @method static YesNo YES
  * @method static YesNo NO
  */
-abstract class YesNo extends Enum
+abstract class YesNo extends ZEnum
 {
 
 }

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -1,5 +1,5 @@
 suites:
     project_stats:
-        namespace: Zlikavac32\Enum
-        psr4_prefix: Zlikavac32\Enum
+        namespace: Zlikavac32\ZEnum
+        psr4_prefix: Zlikavac32\ZEnum
 formatter.name: dot

--- a/spec/EnumNotFoundExceptionSpec.php
+++ b/spec/EnumNotFoundExceptionSpec.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace spec\Zlikavac32\Enum;
+namespace spec\Zlikavac32\ZEnum;
 
 use Exception;
 use PhpSpec\ObjectBehavior;
-use Zlikavac32\Enum\EnumNotFoundException;
+use Zlikavac32\ZEnum\EnumNotFoundException;
 
 class EnumNotFoundExceptionSpec extends ObjectBehavior
 {

--- a/spec/UnhandledEnumExceptionSpec.php
+++ b/spec/UnhandledEnumExceptionSpec.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace spec\Zlikavac32\Enum;
+namespace spec\Zlikavac32\ZEnum;
 
 use PhpSpec\ObjectBehavior;
-use Zlikavac32\Enum\Enum;
-use Zlikavac32\Enum\UnhandledEnumException;
+use Zlikavac32\ZEnum\ZEnum;
+use Zlikavac32\ZEnum\UnhandledEnumException;
 
 class UnhandledEnumExceptionSpec extends ObjectBehavior
 {
@@ -24,7 +24,7 @@ class UnhandledEnumExceptionSpec extends ObjectBehavior
     public function it_should_have_correct_message(): void
     {
         $this->getMessage()
-            ->shouldReturn('Enum spec\Zlikavac32\Enum\FooEnum::FOO() is left unhandled');
+            ->shouldReturn('Enum spec\Zlikavac32\ZEnum\FooEnum::FOO() is left unhandled');
     }
 
     public function it_should_have_correct_enum(): void
@@ -36,7 +36,7 @@ class UnhandledEnumExceptionSpec extends ObjectBehavior
     public function it_should_have_correct_enum_fqn(): void
     {
         $this->enumFqn()
-            ->shouldReturn('spec\Zlikavac32\Enum\FooEnum');
+            ->shouldReturn('spec\Zlikavac32\ZEnum\FooEnum');
     }
 }
 
@@ -45,7 +45,7 @@ class UnhandledEnumExceptionSpec extends ObjectBehavior
  *
  * @method static FooEnum FOO
  */
-abstract class FooEnum extends Enum
+abstract class FooEnum extends ZEnum
 {
 
 }

--- a/src/EnumNotFoundException.php
+++ b/src/EnumNotFoundException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum;
+namespace Zlikavac32\ZEnum;
 
 use LogicException;
 use Throwable;

--- a/src/UnhandledEnumException.php
+++ b/src/UnhandledEnumException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum;
+namespace Zlikavac32\ZEnum;
 
 use LogicException;
 
@@ -11,7 +11,7 @@ class UnhandledEnumException extends LogicException
 
     private string $enumFqn;
 
-    public function __construct(public Enum $enum)
+    public function __construct(public ZEnum $enum)
     {
         $fqn = get_parent_class($enum);
 
@@ -20,7 +20,7 @@ class UnhandledEnumException extends LogicException
         $this->enumFqn = $fqn;
     }
 
-    public function enum(): Enum
+    public function enum(): ZEnum
     {
         return $this->enum;
     }

--- a/src/ZEnum.php
+++ b/src/ZEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum;
+namespace Zlikavac32\ZEnum;
 
 use ArrayIterator;
 use InvalidArgumentException;
@@ -18,10 +18,10 @@ use function get_class;
 use function get_parent_class;
 use function sprintf;
 
-abstract class Enum implements Serializable, JsonSerializable
+abstract class ZEnum implements Serializable, JsonSerializable
 {
     /**
-     * @var Enum[][]
+     * @var ZEnum[][]
      */
     private static array $existingEnums = [];
     /**
@@ -80,7 +80,7 @@ abstract class Enum implements Serializable, JsonSerializable
         return $this->name;
     }
 
-    final public function isAnyOf(Enum ...$enums): bool
+    final public function isAnyOf(ZEnum ...$enums): bool
     {
         $this->assertCorrectlyInitialized();
 
@@ -184,7 +184,7 @@ abstract class Enum implements Serializable, JsonSerializable
      *
      * @return static
      */
-    public static function valueOf(string $name): Enum
+    public static function valueOf(string $name): ZEnum
     {
         return self::__callStatic($name, []);
     }
@@ -195,7 +195,7 @@ abstract class Enum implements Serializable, JsonSerializable
      *
      * @return static
      */
-    final public static function __callStatic($name, $arguments): Enum
+    final public static function __callStatic($name, $arguments): ZEnum
     {
         if (count($arguments) > 0) {
             throw new InvalidArgumentException(
@@ -218,7 +218,7 @@ abstract class Enum implements Serializable, JsonSerializable
     }
 
     /**
-     * @return Enum[]
+     * @return ZEnum[]
      */
     private static function retrieveCurrentContextEnumerations(): array
     {
@@ -250,7 +250,7 @@ abstract class Enum implements Serializable, JsonSerializable
 
         $enumNames = self::resolveMethodsFromDocblock($class);
 
-        /* @var Enum[] $enumObjects */
+        /* @var ZEnum[] $enumObjects */
         $enumObjects = static::enumerate();
 
         $objects = self::normalizeElementsArray($class, $enumNames, $enumObjects);

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum;
+namespace Zlikavac32\ZEnum;
 
 use LogicException;
 use ReflectionClass;
@@ -16,15 +16,15 @@ use function preg_match;
 use function sprintf;
 
 /**
- * @throws LogicException If value in $fqn is not a class extending Zlikavac32\Enum\Enum
+ * @throws LogicException If value in $fqn is not a class extending Zlikavac32\ZEnum\Enum
  */
 function assertFqnIsEnumClass(string $fqn): void
 {
-    if (is_subclass_of($fqn, Enum::class)) {
+    if (is_subclass_of($fqn, ZEnum::class)) {
         return ;
     }
 
-    throw new LogicException(sprintf('%s does not have %s as it\'s parent', $fqn, Enum::class));
+    throw new LogicException(sprintf('%s does not have %s as it\'s parent', $fqn, ZEnum::class));
 }
 
 /**
@@ -32,7 +32,7 @@ function assertFqnIsEnumClass(string $fqn): void
  *
  * Currently they are:
  *   - enum class must be abstract
- *   - no class between enum class and Zlikavac32\Enum\Enum (both exclusive) can implement enumerate() method
+ *   - no class between enum class and Zlikavac32\ZEnum\Enum (both exclusive) can implement enumerate() method
  *   - every class in the chain must be abstract
  *
  * @throws ReflectionException If something went wrong in reflection API
@@ -45,7 +45,7 @@ function assertEnumClassAdheresConstraints(string $fqn): void {
 }
 
 /**
- * Functions asserts that parents (except for Zlikavac32\Enum\Enum) are abstract and do not define enumerate() method.
+ * Functions asserts that parents (except for Zlikavac32\ZEnum\Enum) are abstract and do not define enumerate() method.
  *
  * @throws ReflectionException If something went wrong in reflection API
  * @throws LogicException If one of parents is not abstract
@@ -58,7 +58,7 @@ function assertEnumClassParentsAdhereConstraints(string $fqn): void {
 
         $declaringClass = $reflectionMethod->getDeclaringClass();
 
-        if ($declaringClass->name !== Enum::class) {
+        if ($declaringClass->name !== ZEnum::class) {
             throw new LogicException(
                 sprintf('Enum %s extends %s which already defines enumerate() method', $fqn, $parent)
             );

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -2,34 +2,34 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests;
+namespace Zlikavac32\ZEnum\Tests;
 
 use Error;
 use LogicException;
 use PHPUnit\Framework\TestCase;
-use Zlikavac32\Enum\Tests\Fixtures\AbstractEnumWithoutEnumerate;
-use Zlikavac32\Enum\Tests\Fixtures\DuplicateNameEnum;
-use Zlikavac32\Enum\Tests\Fixtures\EnumThatDependsOnEnum;
-use Zlikavac32\Enum\Tests\Fixtures\EnumThatEnumeratesToLittle;
-use Zlikavac32\Enum\Tests\Fixtures\EnumThatEnumeratesToMuch;
-use Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsNonAbstractEnumWithoutEnumerate;
-use Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsValidObjectsEnum;
-use Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsValidStringEnum;
-use Zlikavac32\Enum\Tests\Fixtures\ValidEnumWithOneParent;
-use Zlikavac32\Enum\Tests\Fixtures\EnumWithSomeVeryVeryLongNameA;
-use Zlikavac32\Enum\Tests\Fixtures\EnumWithSomeVeryVeryLongNameB;
-use Zlikavac32\Enum\Tests\Fixtures\InvalidAliasNameEnum;
-use Zlikavac32\Enum\Tests\Fixtures\InvalidObjectAliasEnumerationObjectsEnum;
-use Zlikavac32\Enum\Tests\Fixtures\InvalidOverrideConstructorEnum;
-use Zlikavac32\Enum\Tests\Fixtures\NameWithinEnumerateEnum;
-use Zlikavac32\Enum\Tests\Fixtures\NoPHPDocMethodEnum;
-use Zlikavac32\Enum\Tests\Fixtures\NonAbstractEnum;
-use Zlikavac32\Enum\Tests\Fixtures\NonObjectEnumerationObjectsEnum;
-use Zlikavac32\Enum\Tests\Fixtures\OrdinalWithinEnumerateEnum;
-use Zlikavac32\Enum\Tests\Fixtures\ValidObjectsEnum;
-use Zlikavac32\Enum\Tests\Fixtures\ValidStringEnum;
-use Zlikavac32\Enum\Tests\Fixtures\WrongClassEnumerationObjectsEnum;
-use Zlikavac32\Enum\Tests\Fixtures\ZeroLengthEnumerationObjectsEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\AbstractEnumWithoutEnumerate;
+use Zlikavac32\ZEnum\Tests\Fixtures\DuplicateNameEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\EnumThatDependsOnEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\EnumThatEnumeratesToLittle;
+use Zlikavac32\ZEnum\Tests\Fixtures\EnumThatEnumeratesToMuch;
+use Zlikavac32\ZEnum\Tests\Fixtures\EnumThatExtendsNonAbstractEnumWithoutEnumerate;
+use Zlikavac32\ZEnum\Tests\Fixtures\EnumThatExtendsValidObjectsEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\EnumThatExtendsValidStringEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\ValidEnumWithOneParent;
+use Zlikavac32\ZEnum\Tests\Fixtures\EnumWithSomeVeryVeryLongNameA;
+use Zlikavac32\ZEnum\Tests\Fixtures\EnumWithSomeVeryVeryLongNameB;
+use Zlikavac32\ZEnum\Tests\Fixtures\InvalidAliasNameEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\InvalidObjectAliasEnumerationObjectsEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\InvalidOverrideConstructorEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\NameWithinEnumerateEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\NoPHPDocMethodEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\NonAbstractEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\NonObjectEnumerationObjectsEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\OrdinalWithinEnumerateEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\ValidObjectsEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\ValidStringEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\WrongClassEnumerationObjectsEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\ZeroLengthEnumerationObjectsEnum;
 use function iterator_to_array;
 use function json_encode;
 
@@ -76,7 +76,7 @@ class EnumTest extends TestCase
     public function testThatOrdinalThrowExceptionUntilValueIsDefined(): void
     {
         $this->expectException(Error::class);
-        $this->expectExceptionMessage('Typed property Zlikavac32\Enum\Enum::$ordinal must not be accessed before initializatio');
+        $this->expectExceptionMessage('Typed property Zlikavac32\ZEnum\ZEnum::$ordinal must not be accessed before initializatio');
 
         OrdinalWithinEnumerateEnum::ENUM_A();
     }
@@ -84,7 +84,7 @@ class EnumTest extends TestCase
     public function testThatNameThrowExceptionUntilValueIsDefined(): void
     {
         $this->expectException(Error::class);
-        $this->expectExceptionMessage('Typed property Zlikavac32\Enum\Enum::$name must not be accessed before initialization');
+        $this->expectExceptionMessage('Typed property Zlikavac32\ZEnum\ZEnum::$name must not be accessed before initialization');
 
         NameWithinEnumerateEnum::ENUM_A();
     }
@@ -127,7 +127,7 @@ class EnumTest extends TestCase
     public function testThatValueOfThrowsExceptionWhenEnumDoesNotExist(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum element I_DONT_EXIST missing in Zlikavac32\Enum\Tests\Fixtures\ValidObjectsEnum');
+        $this->expectExceptionMessage('Enum element I_DONT_EXIST missing in Zlikavac32\ZEnum\Tests\Fixtures\ValidObjectsEnum');
 
         ValidObjectsEnum::valueOf('I_DONT_EXIST');
     }
@@ -189,7 +189,7 @@ class EnumTest extends TestCase
     public function testThatEnumObjectCallsMustBeWithoutArguments(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('No argument must be provided when calling Zlikavac32\Enum\Tests\Fixtures\ValidObjectsEnum::ENUM_B');
+        $this->expectExceptionMessage('No argument must be provided when calling Zlikavac32\ZEnum\Tests\Fixtures\ValidObjectsEnum::ENUM_B');
 
         ValidObjectsEnum::ENUM_B(0);
     }
@@ -197,7 +197,7 @@ class EnumTest extends TestCase
     public function testThatZeroLengthEnumerationObjectConfigurationThrowsException(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum Zlikavac32\Enum\Tests\Fixtures\ZeroLengthEnumerationObjectsEnum must define at least one element');
+        $this->expectExceptionMessage('Enum Zlikavac32\ZEnum\Tests\Fixtures\ZeroLengthEnumerationObjectsEnum must define at least one element');
 
         ZeroLengthEnumerationObjectsEnum::iterator();
     }
@@ -205,7 +205,7 @@ class EnumTest extends TestCase
     public function testThatNonAbstractEnumThrowsException(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum Zlikavac32\Enum\Tests\Fixtures\NonAbstractEnum must be declared as abstract');
+        $this->expectExceptionMessage('Enum Zlikavac32\ZEnum\Tests\Fixtures\NonAbstractEnum must be declared as abstract');
 
         NonAbstractEnum::ENUM_A();
     }
@@ -221,7 +221,7 @@ class EnumTest extends TestCase
     public function testThatDefaultEnumerationObjectConfigurationThrowsException(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('You must provide PHPDoc for static methods in your enum class Zlikavac32\Enum\Tests\Fixtures\NoPHPDocMethodEnum');
+        $this->expectExceptionMessage('You must provide PHPDoc for static methods in your enum class Zlikavac32\ZEnum\Tests\Fixtures\NoPHPDocMethodEnum');
 
         NoPHPDocMethodEnum::iterator();
     }
@@ -229,7 +229,7 @@ class EnumTest extends TestCase
     public function testThatAccessingNonExistingEnumThrowsException(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum element I_DONT_EXIST missing in Zlikavac32\Enum\Tests\Fixtures\ValidObjectsEnum');
+        $this->expectExceptionMessage('Enum element I_DONT_EXIST missing in Zlikavac32\ZEnum\Tests\Fixtures\ValidObjectsEnum');
 
         ValidObjectsEnum::I_DONT_EXIST();
     }
@@ -237,7 +237,7 @@ class EnumTest extends TestCase
     public function testThatInvalidObjectAliasThrowsException(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Element name 0 in enum Zlikavac32\Enum\Tests\Fixtures\InvalidObjectAliasEnumerationObjectsEnum is not valid');
+        $this->expectExceptionMessage('Element name 0 in enum Zlikavac32\ZEnum\Tests\Fixtures\InvalidObjectAliasEnumerationObjectsEnum is not valid');
 
         InvalidObjectAliasEnumerationObjectsEnum::iterator();
     }
@@ -245,7 +245,7 @@ class EnumTest extends TestCase
     public function testThatWrongEnumInstanceThrowsException(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum element object in enum Zlikavac32\Enum\Tests\Fixtures\WrongClassEnumerationObjectsEnum must be an instance of Zlikavac32\Enum\Tests\Fixtures\WrongClassEnumerationObjectsEnum (an instance of Zlikavac32\Enum\Tests\Fixtures\AWrongClassEnumerationObjectsDummyEnum received)');
+        $this->expectExceptionMessage('Enum element object in enum Zlikavac32\ZEnum\Tests\Fixtures\WrongClassEnumerationObjectsEnum must be an instance of Zlikavac32\ZEnum\Tests\Fixtures\WrongClassEnumerationObjectsEnum (an instance of Zlikavac32\ZEnum\Tests\Fixtures\AWrongClassEnumerationObjectsDummyEnum received)');
 
         WrongClassEnumerationObjectsEnum::iterator();
     }
@@ -253,7 +253,7 @@ class EnumTest extends TestCase
     public function testThatObjectEnumThrowsException(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum element object in enum Zlikavac32\Enum\Tests\Fixtures\NonObjectEnumerationObjectsEnum must be an instance of Zlikavac32\Enum\Tests\Fixtures\NonObjectEnumerationObjectsEnum (integer received)');
+        $this->expectExceptionMessage('Enum element object in enum Zlikavac32\ZEnum\Tests\Fixtures\NonObjectEnumerationObjectsEnum must be an instance of Zlikavac32\ZEnum\Tests\Fixtures\NonObjectEnumerationObjectsEnum (integer received)');
 
         NonObjectEnumerationObjectsEnum::iterator();
     }
@@ -301,7 +301,7 @@ class EnumTest extends TestCase
     public function testThatConstructMustBeCalledForName(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('It seems that enum is not correctly initialized. Did you forget to call parent::__construct() in enum Zlikavac32\Enum\Tests\Fixtures\InvalidOverrideConstructorEnum?');
+        $this->expectExceptionMessage('It seems that enum is not correctly initialized. Did you forget to call parent::__construct() in enum Zlikavac32\ZEnum\Tests\Fixtures\InvalidOverrideConstructorEnum?');
 
         (new InvalidOverrideConstructorEnum())->name();
     }
@@ -309,7 +309,7 @@ class EnumTest extends TestCase
     public function testThatConstructMustBeCalledForOrdinal(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('It seems that enum is not correctly initialized. Did you forget to call parent::__construct() in enum Zlikavac32\Enum\Tests\Fixtures\InvalidOverrideConstructorEnum?');
+        $this->expectExceptionMessage('It seems that enum is not correctly initialized. Did you forget to call parent::__construct() in enum Zlikavac32\ZEnum\Tests\Fixtures\InvalidOverrideConstructorEnum?');
 
         (new InvalidOverrideConstructorEnum())->ordinal();
     }
@@ -317,7 +317,7 @@ class EnumTest extends TestCase
     public function testThatConstructMustBeCalledForIsAnyOf(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('It seems that enum is not correctly initialized. Did you forget to call parent::__construct() in enum Zlikavac32\Enum\Tests\Fixtures\InvalidOverrideConstructorEnum?');
+        $this->expectExceptionMessage('It seems that enum is not correctly initialized. Did you forget to call parent::__construct() in enum Zlikavac32\ZEnum\Tests\Fixtures\InvalidOverrideConstructorEnum?');
 
         (new InvalidOverrideConstructorEnum())->isAnyOf();
     }
@@ -325,7 +325,7 @@ class EnumTest extends TestCase
     public function testThatNameThrowsExceptionWhenNotConstructedCorrectly(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('It seems you tried to manually create enum outside of enumerate() method for enum Zlikavac32\Enum\Tests\Fixtures\NonAbstractEnum');
+        $this->expectExceptionMessage('It seems you tried to manually create enum outside of enumerate() method for enum Zlikavac32\ZEnum\Tests\Fixtures\NonAbstractEnum');
 
         (new NonAbstractEnum())->name();
     }
@@ -333,7 +333,7 @@ class EnumTest extends TestCase
     public function testThatOrdinalThrowsExceptionWhenNotConstructedCorrectly(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('It seems you tried to manually create enum outside of enumerate() method for enum Zlikavac32\Enum\Tests\Fixtures\NonAbstractEnum');
+        $this->expectExceptionMessage('It seems you tried to manually create enum outside of enumerate() method for enum Zlikavac32\ZEnum\Tests\Fixtures\NonAbstractEnum');
 
         (new NonAbstractEnum())->ordinal();
     }
@@ -341,7 +341,7 @@ class EnumTest extends TestCase
     public function testThatToStringThrowsExceptionWhenNotConstructedCorrectly(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('It seems you tried to manually create enum outside of enumerate() method for enum Zlikavac32\Enum\Tests\Fixtures\NonAbstractEnum');
+        $this->expectExceptionMessage('It seems you tried to manually create enum outside of enumerate() method for enum Zlikavac32\ZEnum\Tests\Fixtures\NonAbstractEnum');
 
         (new NonAbstractEnum())->__toString();
     }
@@ -349,7 +349,7 @@ class EnumTest extends TestCase
     public function testThatDuplicateElementThrowsException(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Duplicate element ENUM_A exists in enum Zlikavac32\Enum\Tests\Fixtures\DuplicateNameEnum');
+        $this->expectExceptionMessage('Duplicate element ENUM_A exists in enum Zlikavac32\ZEnum\Tests\Fixtures\DuplicateNameEnum');
 
         DuplicateNameEnum::ENUM_A();
     }
@@ -370,7 +370,7 @@ class EnumTest extends TestCase
     public function testThatNonDefiningEnumClassInChainMustNotDefinePHPDoc(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsValidStringEnum extends Zlikavac32\Enum\Tests\Fixtures\ValidStringEnum which already defines enum names in PHPDoc');
+        $this->expectExceptionMessage('Enum Zlikavac32\ZEnum\Tests\Fixtures\EnumThatExtendsValidStringEnum extends Zlikavac32\ZEnum\Tests\Fixtures\ValidStringEnum which already defines enum names in PHPDoc');
 
         EnumThatExtendsValidStringEnum::ENUM_A();
     }
@@ -378,7 +378,7 @@ class EnumTest extends TestCase
     public function testThatNonDefiningEnumClassInChainMustNotDefineEnumerate(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsValidObjectsEnum extends Zlikavac32\Enum\Tests\Fixtures\ValidObjectsEnum which already defines enumerate() method');
+        $this->expectExceptionMessage('Enum Zlikavac32\ZEnum\Tests\Fixtures\EnumThatExtendsValidObjectsEnum extends Zlikavac32\ZEnum\Tests\Fixtures\ValidObjectsEnum which already defines enumerate() method');
 
         EnumThatExtendsValidObjectsEnum::ENUM_A();
     }
@@ -386,7 +386,7 @@ class EnumTest extends TestCase
     public function testThatNonDefiningEnumClassInChainMustBeAbstract(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum Zlikavac32\Enum\Tests\Fixtures\NonAbstractEnumWithoutEnumerate must be declared as abstract');
+        $this->expectExceptionMessage('Enum Zlikavac32\ZEnum\Tests\Fixtures\NonAbstractEnumWithoutEnumerate must be declared as abstract');
 
         EnumThatExtendsNonAbstractEnumWithoutEnumerate::ENUM_A();
     }
@@ -400,7 +400,7 @@ class EnumTest extends TestCase
     public function testThatExceptionIsThrowForEnumThatEnumeratesToMuch(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum Zlikavac32\Enum\Tests\Fixtures\EnumThatEnumeratesToMuch enumerates [ENUM_B, ENUM_C] which are not found in PHPDoc');
+        $this->expectExceptionMessage('Enum Zlikavac32\ZEnum\Tests\Fixtures\EnumThatEnumeratesToMuch enumerates [ENUM_B, ENUM_C] which are not found in PHPDoc');
 
         EnumThatEnumeratesToMuch::ENUM_A();
     }
@@ -408,7 +408,7 @@ class EnumTest extends TestCase
     public function testThatExceptionIsThrowForEnumThatEnumeratesToLittle(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum Zlikavac32\Enum\Tests\Fixtures\EnumThatEnumeratesToLittle does not enumerate [ENUM_B, ENUM_C] which are found in PHPDoc');
+        $this->expectExceptionMessage('Enum Zlikavac32\ZEnum\Tests\Fixtures\EnumThatEnumeratesToLittle does not enumerate [ENUM_B, ENUM_C] which are found in PHPDoc');
 
         EnumThatEnumeratesToLittle::ENUM_A();
     }
@@ -417,14 +417,14 @@ class EnumTest extends TestCase
     {
         // to avoid editor accidentally deleting \r, this enum fixture is evaluated
         $code = <<<'PHP'
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static EnumWithCarriageReturnInMethod ENUM_A%s
  */
-abstract class EnumWithCarriageReturnInMethod extends Enum
+abstract class EnumWithCarriageReturnInMethod extends ZEnum
 {
 
 }
@@ -434,7 +434,7 @@ PHP;
 
         $this->assertSame(
             0,
-            \Zlikavac32\Enum\Tests\Fixtures\EnumWithCarriageReturnInMethod::ENUM_A()
+            \Zlikavac32\ZEnum\Tests\Fixtures\EnumWithCarriageReturnInMethod::ENUM_A()
                             ->ordinal()
         );
     }

--- a/tests/Fixtures/AbstractEnumWithoutEnumerate.php
+++ b/tests/Fixtures/AbstractEnumWithoutEnumerate.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
-abstract class AbstractEnumWithoutEnumerate extends Enum
+abstract class AbstractEnumWithoutEnumerate extends ZEnum
 {
 
 }

--- a/tests/Fixtures/DuplicateNameEnum.php
+++ b/tests/Fixtures/DuplicateNameEnum.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static DuplicateNameEnum ENUM_A
  * @method static DuplicateNameEnum ENUM_A
  */
-abstract class DuplicateNameEnum extends Enum
+abstract class DuplicateNameEnum extends ZEnum
 {
 
 }

--- a/tests/Fixtures/EnumThatDependsOnEnum.php
+++ b/tests/Fixtures/EnumThatDependsOnEnum.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static EnumThatDependsOnEnum ENUM_A
  */
-abstract class EnumThatDependsOnEnum extends Enum
+abstract class EnumThatDependsOnEnum extends ZEnum
 {
     /**
      * @var ValidStringEnum

--- a/tests/Fixtures/EnumThatEnumeratesToLittle.php
+++ b/tests/Fixtures/EnumThatEnumeratesToLittle.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static EnumThatEnumeratesToLittle ENUM_A
  * @method static EnumThatEnumeratesToLittle ENUM_B
  * @method static EnumThatEnumeratesToLittle ENUM_C
  */
-abstract class EnumThatEnumeratesToLittle extends Enum
+abstract class EnumThatEnumeratesToLittle extends ZEnum
 {
     protected static function enumerate(): array
     {

--- a/tests/Fixtures/EnumThatEnumeratesToMuch.php
+++ b/tests/Fixtures/EnumThatEnumeratesToMuch.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static EnumThatEnumeratesToMuch ENUM_A
  */
-abstract class EnumThatEnumeratesToMuch extends Enum
+abstract class EnumThatEnumeratesToMuch extends ZEnum
 {
     protected static function enumerate(): array
     {

--- a/tests/Fixtures/EnumThatExtendsNonAbstractEnumWithoutEnumerate.php
+++ b/tests/Fixtures/EnumThatExtendsNonAbstractEnumWithoutEnumerate.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
 /**
  * @method static EnumThatExtendsNonAbstractEnumWithoutEnumerate ENUM_A

--- a/tests/Fixtures/EnumThatExtendsValidObjectsEnum.php
+++ b/tests/Fixtures/EnumThatExtendsValidObjectsEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
 /**
  * @method static EnumThatExtendsValidObjectsEnum ENUM_A

--- a/tests/Fixtures/EnumThatExtendsValidStringEnum.php
+++ b/tests/Fixtures/EnumThatExtendsValidStringEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
 /**
  * @method static EnumThatExtendsValidStringEnum ENUM_A

--- a/tests/Fixtures/EnumWithSomeVeryVeryLongNameA.php
+++ b/tests/Fixtures/EnumWithSomeVeryVeryLongNameA.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static EnumWithSomeVeryVeryLongNameA ENUM_A
  * @method static EnumWithSomeVeryVeryLongNameA ENUM_B
  */
-abstract class EnumWithSomeVeryVeryLongNameA extends Enum
+abstract class EnumWithSomeVeryVeryLongNameA extends ZEnum
 {
 
 }

--- a/tests/Fixtures/EnumWithSomeVeryVeryLongNameB.php
+++ b/tests/Fixtures/EnumWithSomeVeryVeryLongNameB.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static EnumWithSomeVeryVeryLongNameB ENUM_A
  * @method static EnumWithSomeVeryVeryLongNameB ENUM_B
  */
-abstract class EnumWithSomeVeryVeryLongNameB extends Enum
+abstract class EnumWithSomeVeryVeryLongNameB extends ZEnum
 {
 
 }

--- a/tests/Fixtures/InvalidAliasNameEnum.php
+++ b/tests/Fixtures/InvalidAliasNameEnum.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static InvalidAliasNameEnum 3ID
  */
-abstract class InvalidAliasNameEnum extends Enum
+abstract class InvalidAliasNameEnum extends ZEnum
 {
 
 }

--- a/tests/Fixtures/InvalidObjectAliasEnumerationObjectsEnum.php
+++ b/tests/Fixtures/InvalidObjectAliasEnumerationObjectsEnum.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static InvalidObjectAliasEnumerationObjectsEnum ENUM
  */
-abstract class InvalidObjectAliasEnumerationObjectsEnum extends Enum
+abstract class InvalidObjectAliasEnumerationObjectsEnum extends ZEnum
 {
     protected static function enumerate(): array
     {

--- a/tests/Fixtures/InvalidOverrideConstructorEnum.php
+++ b/tests/Fixtures/InvalidOverrideConstructorEnum.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static InvalidOverrideConstructorEnum ENUM_A
  */
-class InvalidOverrideConstructorEnum extends Enum
+class InvalidOverrideConstructorEnum extends ZEnum
 {
     public function __construct() { }
 

--- a/tests/Fixtures/NameWithinEnumerateEnum.php
+++ b/tests/Fixtures/NameWithinEnumerateEnum.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static NameWithinEnumerateEnum ENUM_A
  */
-abstract class NameWithinEnumerateEnum extends Enum
+abstract class NameWithinEnumerateEnum extends ZEnum
 {
     protected static function enumerate(): array
     {

--- a/tests/Fixtures/NoPHPDocMethodEnum.php
+++ b/tests/Fixtures/NoPHPDocMethodEnum.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
-abstract class NoPHPDocMethodEnum extends Enum
+abstract class NoPHPDocMethodEnum extends ZEnum
 {
 
 }

--- a/tests/Fixtures/NonAbstractEnum.php
+++ b/tests/Fixtures/NonAbstractEnum.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static NonAbstractEnum ENUM_A
  */
-class NonAbstractEnum extends Enum
+class NonAbstractEnum extends ZEnum
 {
 
 }

--- a/tests/Fixtures/NonAbstractEnumWithoutEnumerate.php
+++ b/tests/Fixtures/NonAbstractEnumWithoutEnumerate.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
-class NonAbstractEnumWithoutEnumerate extends Enum
+class NonAbstractEnumWithoutEnumerate extends ZEnum
 {
 
 }

--- a/tests/Fixtures/NonObjectEnumerationObjectsEnum.php
+++ b/tests/Fixtures/NonObjectEnumerationObjectsEnum.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static NonObjectEnumerationObjectsEnum ALIAS
  */
-abstract class NonObjectEnumerationObjectsEnum extends Enum
+abstract class NonObjectEnumerationObjectsEnum extends ZEnum
 {
     protected static function enumerate(): array
     {

--- a/tests/Fixtures/OrdinalWithinEnumerateEnum.php
+++ b/tests/Fixtures/OrdinalWithinEnumerateEnum.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static OrdinalWithinEnumerateEnum ENUM_A
  */
-abstract class OrdinalWithinEnumerateEnum extends Enum
+abstract class OrdinalWithinEnumerateEnum extends ZEnum
 {
     protected static function enumerate(): array
     {

--- a/tests/Fixtures/ValidEnumWithOneParent.php
+++ b/tests/Fixtures/ValidEnumWithOneParent.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
 /**
  * @method static ValidStringEnum ENUM_A

--- a/tests/Fixtures/ValidObjectsEnum.php
+++ b/tests/Fixtures/ValidObjectsEnum.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static ValidObjectsEnum ENUM_A
  * @method static ValidObjectsEnum ENUM_B
  */
-abstract class ValidObjectsEnum extends Enum
+abstract class ValidObjectsEnum extends ZEnum
 {
     protected static function enumerate(): array
     {

--- a/tests/Fixtures/ValidStringEnum.php
+++ b/tests/Fixtures/ValidStringEnum.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static ValidStringEnum ENUM_A
  * @method static ValidStringEnum ENUM_B
  */
-abstract class ValidStringEnum extends Enum
+abstract class ValidStringEnum extends ZEnum
 {
 
 }

--- a/tests/Fixtures/WrongClassEnumerationObjectsEnum.php
+++ b/tests/Fixtures/WrongClassEnumerationObjectsEnum.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  * @method static WrongClassEnumerationObjectsEnum ALIAS
  */
-abstract class WrongClassEnumerationObjectsEnum extends Enum
+abstract class WrongClassEnumerationObjectsEnum extends ZEnum
 {
     protected static function enumerate(): array
     {
@@ -22,7 +22,7 @@ abstract class WrongClassEnumerationObjectsEnum extends Enum
 /**
  * @method static WrongClassEnumerationObjectsDummyEnum A
  */
-abstract class WrongClassEnumerationObjectsDummyEnum extends Enum
+abstract class WrongClassEnumerationObjectsDummyEnum extends ZEnum
 {
     protected static function enumerate(): array
     {

--- a/tests/Fixtures/ZeroLengthEnumerationObjectsEnum.php
+++ b/tests/Fixtures/ZeroLengthEnumerationObjectsEnum.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests\Fixtures;
+namespace Zlikavac32\ZEnum\Tests\Fixtures;
 
-use Zlikavac32\Enum\Enum;
+use Zlikavac32\ZEnum\ZEnum;
 
 /**
  *
  */
-abstract class ZeroLengthEnumerationObjectsEnum extends Enum
+abstract class ZeroLengthEnumerationObjectsEnum extends ZEnum
 {
 
 }

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -2,25 +2,25 @@
 
 declare(strict_types=1);
 
-namespace Zlikavac32\Enum\Tests;
+namespace Zlikavac32\ZEnum\Tests;
 
 use LogicException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Throwable;
-use Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsNonAbstractEnumWithoutEnumerate;
-use Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsValidObjectsEnum;
-use Zlikavac32\Enum\Tests\Fixtures\NonAbstractEnum;
-use Zlikavac32\Enum\Tests\Fixtures\ValidEnumWithOneParent;
-use Zlikavac32\Enum\Tests\Fixtures\ValidStringEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\EnumThatExtendsNonAbstractEnumWithoutEnumerate;
+use Zlikavac32\ZEnum\Tests\Fixtures\EnumThatExtendsValidObjectsEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\NonAbstractEnum;
+use Zlikavac32\ZEnum\Tests\Fixtures\ValidEnumWithOneParent;
+use Zlikavac32\ZEnum\Tests\Fixtures\ValidStringEnum;
 use function sprintf;
-use function Zlikavac32\Enum\assertElementNameIsString;
-use function Zlikavac32\Enum\assertEnumClassIsAbstract;
-use function Zlikavac32\Enum\assertFqnIsEnumClass;
-use function Zlikavac32\Enum\assertEnumClassParentsAdhereConstraints;
-use function Zlikavac32\Enum\assertValidEnumCollection;
-use function Zlikavac32\Enum\assertValidEnumElementObjectType;
-use function Zlikavac32\Enum\assertValidNamePattern;
+use function Zlikavac32\ZEnum\assertElementNameIsString;
+use function Zlikavac32\ZEnum\assertEnumClassIsAbstract;
+use function Zlikavac32\ZEnum\assertFqnIsEnumClass;
+use function Zlikavac32\ZEnum\assertEnumClassParentsAdhereConstraints;
+use function Zlikavac32\ZEnum\assertValidEnumCollection;
+use function Zlikavac32\ZEnum\assertValidEnumElementObjectType;
+use function Zlikavac32\ZEnum\assertValidNamePattern;
 
 class functionsTest extends TestCase
 {
@@ -39,7 +39,7 @@ class functionsTest extends TestCase
     public function testThatFqnNotRepresentingValidEnumClassDoesNotPassAssert(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('stdClass does not have Zlikavac32\Enum\Enum as it\'s parent');
+        $this->expectExceptionMessage('stdClass does not have Zlikavac32\ZEnum\ZEnum as it\'s parent');
 
         assertFqnIsEnumClass(stdClass::class);
     }
@@ -77,7 +77,7 @@ class functionsTest extends TestCase
     public function testThatExceptionIsThrownOnNonAbstractClass(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum Zlikavac32\Enum\Tests\Fixtures\NonAbstractEnum must be declared as abstract');
+        $this->expectExceptionMessage('Enum Zlikavac32\ZEnum\Tests\Fixtures\NonAbstractEnum must be declared as abstract');
 
         assertEnumClassIsAbstract(NonAbstractEnum::class);
     }
@@ -96,7 +96,7 @@ class functionsTest extends TestCase
     public function testThatExceptionIsThrownWhenElementNameIsObject(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Element name (object instance of stdClass) in enum Zlikavac32\Enum\Tests\Fixtures\ValidStringEnum is not valid');
+        $this->expectExceptionMessage('Element name (object instance of stdClass) in enum Zlikavac32\ZEnum\Tests\Fixtures\ValidStringEnum is not valid');
 
         assertElementNameIsString(ValidStringEnum::class, new stdClass());
     }
@@ -104,7 +104,7 @@ class functionsTest extends TestCase
     public function testThatExceptionIsThrownWhenElementNameIsScalar(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Element name 12467 in enum Zlikavac32\Enum\Tests\Fixtures\ValidStringEnum is not valid');
+        $this->expectExceptionMessage('Element name 12467 in enum Zlikavac32\ZEnum\Tests\Fixtures\ValidStringEnum is not valid');
         assertElementNameIsString(ValidStringEnum::class, 12467);
     }
 
@@ -122,7 +122,7 @@ class functionsTest extends TestCase
     public function testThatExceptionIsThrownWhenElementIsInvalidClassInstance(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum element object in enum Zlikavac32\Enum\Tests\Fixtures\ValidStringEnum must be an instance of Zlikavac32\Enum\Tests\Fixtures\ValidStringEnum (an instance of stdClass received)');
+        $this->expectExceptionMessage('Enum element object in enum Zlikavac32\ZEnum\Tests\Fixtures\ValidStringEnum must be an instance of Zlikavac32\ZEnum\Tests\Fixtures\ValidStringEnum (an instance of stdClass received)');
 
         assertValidEnumElementObjectType(ValidStringEnum::class, new stdClass(), ValidStringEnum::class);
     }
@@ -130,7 +130,7 @@ class functionsTest extends TestCase
     public function testThatExceptionIsThrownWhenElementIsScalar(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum element object in enum Zlikavac32\Enum\Tests\Fixtures\ValidStringEnum must be an instance of Zlikavac32\Enum\Tests\Fixtures\ValidStringEnum (integer received)');
+        $this->expectExceptionMessage('Enum element object in enum Zlikavac32\ZEnum\Tests\Fixtures\ValidStringEnum must be an instance of Zlikavac32\ZEnum\Tests\Fixtures\ValidStringEnum (integer received)');
 
         assertValidEnumElementObjectType(ValidStringEnum::class, 12467, ValidStringEnum::class);
     }
@@ -153,7 +153,7 @@ class functionsTest extends TestCase
     public function testThatExceptionIsThrownWhenCollectionIsNotValid(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Element name 0 in enum Zlikavac32\Enum\Tests\Fixtures\ValidStringEnum is not valid');
+        $this->expectExceptionMessage('Element name 0 in enum Zlikavac32\ZEnum\Tests\Fixtures\ValidStringEnum is not valid');
 
         assertValidEnumCollection(ValidStringEnum::class, [new stdClass()], ValidStringEnum::class);
     }
@@ -166,7 +166,7 @@ class functionsTest extends TestCase
     public function testThatExceptionIsThrownWhenParentHasEnumerate(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsValidObjectsEnum extends Zlikavac32\Enum\Tests\Fixtures\ValidObjectsEnum which already defines enumerate() method');
+        $this->expectExceptionMessage('Enum Zlikavac32\ZEnum\Tests\Fixtures\EnumThatExtendsValidObjectsEnum extends Zlikavac32\ZEnum\Tests\Fixtures\ValidObjectsEnum which already defines enumerate() method');
 
         assertEnumClassParentsAdhereConstraints(EnumThatExtendsValidObjectsEnum::class);
     }
@@ -174,7 +174,7 @@ class functionsTest extends TestCase
     public function testThatExceptionIsThrownWhenParentHasPHPDoc(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum Zlikavac32\Enum\Tests\Fixtures\EnumThatExtendsValidObjectsEnum extends Zlikavac32\Enum\Tests\Fixtures\ValidObjectsEnum which already defines enumerate() method');
+        $this->expectExceptionMessage('Enum Zlikavac32\ZEnum\Tests\Fixtures\EnumThatExtendsValidObjectsEnum extends Zlikavac32\ZEnum\Tests\Fixtures\ValidObjectsEnum which already defines enumerate() method');
 
         assertEnumClassParentsAdhereConstraints(EnumThatExtendsValidObjectsEnum::class);
     }
@@ -182,7 +182,7 @@ class functionsTest extends TestCase
     public function testThatExceptionIsThrownWhenParentIsNotAbstract(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Enum Zlikavac32\Enum\Tests\Fixtures\NonAbstractEnumWithoutEnumerate must be declared as abstract');
+        $this->expectExceptionMessage('Enum Zlikavac32\ZEnum\Tests\Fixtures\NonAbstractEnumWithoutEnumerate must be declared as abstract');
 
         assertEnumClassParentsAdhereConstraints(EnumThatExtendsNonAbstractEnumWithoutEnumerate::class);
     }


### PR DESCRIPTION
Since PHP 8.1 has enum as a keyword, it's no longer possible to have that as a namespace or a class name.